### PR TITLE
Extract urls from tweet

### DIFF
--- a/frontend/src/lib/server/getDataFromTweetUrl.ts
+++ b/frontend/src/lib/server/getDataFromTweetUrl.ts
@@ -1,0 +1,22 @@
+
+/**
+ * Fetch tweet content from Twitter oEmbed API and extract URLs inside the tweet
+ *
+ * @param tweetUrl - The URL of the tweet
+ * @returns An array of URLs inside the tweet
+ */
+async function extractUrlsFromTweetUrl(tweetUrl: string): Promise<string[]> {
+  const response = await fetch(`https://publish.twitter.com/oembed?url=${tweetUrl}`)
+  const data = await response.json()
+  return data.html.match(/href="(https?:\/\/[^\s]+)"/g) || []
+}
+
+type Data = Array<{
+  url: string;
+  // TODO: Define the rest of the data structure
+}>;
+
+export default async function getDataFromTweetUrl(url: string): Promise<Data> {
+  const urls = await extractUrlsFromTweetUrl(url);
+  return urls.map((url) => ({ url }));
+}

--- a/frontend/src/lib/server/getDataFromTweetUrl.ts
+++ b/frontend/src/lib/server/getDataFromTweetUrl.ts
@@ -18,5 +18,8 @@ type Data = Array<{
 
 export default async function getDataFromTweetUrl(url: string): Promise<Data> {
   const urls = await extractUrlsFromTweetUrl(url);
+
+  // TODO: invoke BirdXplorer API to get posts with these URLs
+
   return urls.map((url) => ({ url }));
 }

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -1,3 +1,4 @@
+import getDataFromTweetUrl from '$lib/server/getDataFromTweetUrl';
 import { fail } from '@sveltejs/kit';
 
 export const actions = {
@@ -9,8 +10,7 @@ export const actions = {
                 message: 'Invalid URL'
             })
         }
-        return {
-            url: url
-        }
+        const data = await getDataFromTweetUrl(url);
+        return data
     }
 }


### PR DESCRIPTION
Add a scaffold for `getDataFromTweetUrl`, with a working mechanism that turns twitter URL to the URLs inside.

TODO: invoke BirdXplorer API to get posts with these URLs

Example input:
https://twitter.com/CodeforJapan/status/1819216949567525243

Function output:
![image](https://github.com/user-attachments/assets/7521cdc2-a56b-4d89-872b-854af5524bea)

- - -

From UI:

![image](https://github.com/user-attachments/assets/9e91bd34-90da-4fe6-8c99-e6bf5d5e1f9c)


