### PR TITLE
fix(lib): fix issues in getDataFromTweetUrls

### DIFF
--- a/frontend/src/lib/server/getDataFromTweetUrl.ts
+++ b/frontend/src/lib/server/getDataFromTweetUrl.ts
@@ -1,25 +1,26 @@
-
 /**
- * Fetch tweet content from Twitter oEmbed API and extract URLs inside the tweet
+ * Fetch tweet content from Twitter oEmbed API and extract URLs inside the tweet.
+ * External URLs are using t.co as host.
  *
  * @param tweetUrl - The URL of the tweet
  * @returns An array of URLs inside the tweet
  */
 async function extractUrlsFromTweetUrl(tweetUrl: string): Promise<string[]> {
-  const response = await fetch(`https://publish.twitter.com/oembed?url=${tweetUrl}`)
-  const data = await response.json()
-  return data.html.match(/href="(https?:\/\/[^\s]+)"/g) || []
+	const response = await fetch(`https://publish.twitter.com/oembed?url=${tweetUrl}`);
+	const data = await response.json();
+	const allUrls = [...(data.html as string).matchAll(/href="(https?:\/\/[^\s]+)"/g)];
+	return allUrls.map((m) => m[1]).filter((url) => url.startsWith('https://t.co/'));
 }
 
 type Data = Array<{
-  url: string;
-  // TODO: Define the rest of the data structure
+	url: string;
+	// TODO: Define the rest of the data structure
 }>;
 
 export default async function getDataFromTweetUrl(url: string): Promise<Data> {
-  const urls = await extractUrlsFromTweetUrl(url);
+	const urls = await extractUrlsFromTweetUrl(url);
 
-  // TODO: invoke BirdXplorer API to get posts with these URLs
+	// TODO: invoke BirdXplorer API to get posts with these URLs
 
-  return urls.map((url) => ({ url }));
+	return urls.map((url) => ({ url }));
 }


### PR DESCRIPTION
Fix the following issues

1. Should only extract t.co URLs, which filters out hashtags and other irrelevant URLs
2. Prettier fix

Known issue: tweets with media files will have additional `t.co` URLs. We will just include them for now as we can't find a way to filter them out.

# Examples
Sample of no URLs
https://twitter.com/maaadesign/status/1823675941605753197
--> Empty
![image](https://github.com/user-attachments/assets/78be91c9-f61a-42ae-92c2-e17a38027724)


Sample of one external URL
https://twitter.com/CodeforJapan/status/1808418003517952302
![image](https://github.com/user-attachments/assets/3cf654e0-c100-4508-ad68-31563d527ec4)
